### PR TITLE
fix(signal-strength): handle NaN RSI in mobile/wifi tile styling

### DIFF
--- a/packages/spatial-id-viewer/src/views/mobile/view/hooks/load-models.tsx
+++ b/packages/spatial-id-viewer/src/views/mobile/view/hooks/load-models.tsx
@@ -24,6 +24,11 @@ interface SignalInfo extends Record<string, unknown> {
 }
 const SINGLE = 'single_model';
 const MULTIPLE = 'multiple_models';
+
+const toFiniteNumber = (value: unknown): number | null => {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
 export const useLoadModel = (type: string) => {
   const authInfo = useLatest(useAuthInfo((s) => s.authInfo));
 
@@ -95,12 +100,16 @@ export const processSignal = (area: any, type: string) => {
   const areaType = area.microwave;
   for (const spatialIdentification of areaType[type].voxelValues) {
     const spatialId = spatialIdentification.id.ID;
+    const rsi = toFiniteNumber(spatialIdentification.RSI);
+    if (rsi == null) {
+      continue;
+    }
     try {
       spatialIds.set(
         spatialId,
         SpatialId.fromString<SignalInfo>(spatialId, {
           id: areaId,
-          'RSI (dB)': spatialIdentification.RSI,
+          'RSI (dB)': rsi,
         })
       );
     } catch (e) {
@@ -140,12 +149,16 @@ export const createSignalMap = (
     if (spatialIds.has(spatialId)) {
       continue;
     }
+    const rsi = toFiniteNumber(definition.RSI);
+    if (rsi == null) {
+      continue;
+    }
     try {
       spatialIds.set(
         spatialId,
         SpatialId.fromString<SignalInfo>(spatialId, {
           id: objectId,
-          'RSI (dB)': definition.RSI,
+          'RSI (dB)': rsi,
         })
       );
     } catch (e) {

--- a/packages/spatial-id-viewer/src/views/mobile/view/index.tsx
+++ b/packages/spatial-id-viewer/src/views/mobile/view/index.tsx
@@ -99,12 +99,14 @@ const MobileStrengthViewer = (props: Props) => {
 };
 const tilesetStyleFn = (tileOpacity: number, minRSI: number, maxRSI: number) => {
   return new Cesium3DTileStyle({
-    color: `hsla(
-    (1 - (clamp((\${feature["RSI (dB)"]} - ${minRSI}) / (${maxRSI} - ${minRSI}), 0, 1))) * 2/3,
-      1,
-      0.6,
-      ${tileOpacity}
-    )`,
+    color: `
+      hsla(
+        (1 - (clamp(((\${feature["RSI (dB)"]} === \${feature["RSI (dB)"]} ? \${feature["RSI (dB)"]} : ${minRSI}) - ${minRSI}) / (${maxRSI} - ${minRSI}), 0, 1))) * 2/3,
+        1,
+        0.6,
+        ${tileOpacity}
+      )
+    `,
   });
 };
 

--- a/packages/spatial-id-viewer/src/views/wifi/view/index.tsx
+++ b/packages/spatial-id-viewer/src/views/wifi/view/index.tsx
@@ -69,7 +69,8 @@ const WifiStrengthViewer = (props: Props) => {
 
 const tilesetStyleFn = (tileOpacity: number) =>
   new Cesium3DTileStyle({
-    color: `hsla((1-(clamp(\${feature["RSI (dB)"]} + 120, 1, 60) / 60)) * 2 / 3,
+    color: `hsla(
+      (1-(clamp((\${feature["RSI (dB)"]} === \${feature["RSI (dB)"]} ? \${feature["RSI (dB)"]} : -119) + 120, 1, 60) / 60)) * 2 / 3,
       1,
       0.6,
       ${tileOpacity}


### PR DESCRIPTION
**Summary**

- Signal Strength 表示で、RSI が NaN のデータを受け取った際に Cesium のレンダリングが停止する問題を修正。
- Mobile/Wi-Fi どちらのスタイル式でも、RSI が NaN の場合は最小値側へフォールバックして色計算を継続。
- これにより、問題のあるデータを含んでも画面がクラッシュせず表示を継続可能にした。

**Background**

- 対象 ID の取得時、RSI に非数値が混在すると style 式内で NaN が伝播し、Cesium が RuntimeError を発生して描画停止していた。

**Changes**

- Mobile の tileset style: NaN 判定を追加し、NaN 時は minRSI を使用。
- Wi-Fi の tileset style: 同様に NaN 判定を追加し、最小値相当へフォールバック。
- （必要に応じて）データ取り込み時の RSI 正規化/無効値スキップを併用し、描画層への非数値流入を抑制。

**Validation**

- signal-strength 画面で対象 ID を再取得し、従来の RuntimeError が再発しないことを確認。

